### PR TITLE
rounding out the implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     'Operating System :: OS Independent',
 ]
 dependencies = [
+    'edn_format',
     'requests'
 ]
 

--- a/pyxtdb.py
+++ b/pyxtdb.py
@@ -197,29 +197,34 @@ class Node:
     def match(self, eid, rec, valid_time=None):
         return TxOps(node=self).match(eid, rec, valid_time)
 
-    def query(self, query=None, in_args=None, **kwargs):
+    def query(self, query, in_args=None, **kwargs):
 
-        # handle explicit query string and in-args, if provided
-        if query:
-            query=query.strip()
+        if type(query) is str:
+            query = query.strip()
             assert query.startswith("{") and query.endswith("}")
-            if not in_args:
-                data = "{:query %s}" % query
-            else:
-                data = "{:query %s :in-args %s}" % (query, edn_format.dumps(in_args))
         else:
-            data = None
+            query = edn_format.dumps(query)
+
+        if in_args is not None:
+            if type(in_args) is str:
+                in_args = in_args.strip()
+            else:
+                in_args = edn_format.dumps(in_args)
+
+        if not in_args:
+            data = "{:query %s}" % query
+        else:
+            data = "{:query %s :in-args %s}" % (query, in_args)
 
         # handle url parameters
         known_args = [
-            'query-edn',
-            'in-args-edn',
-            'in-args-json',
             "valid-time",
             'tx-time',
             'tx-id'
         ]
         params = self.parse_kwargs(known_args, kwargs)
+
+        print(f'params {params}\ndata {data}')
 
         action = "query"
         endpoint = "{}/_xtdb/{}".format(self.uri, action)

--- a/pyxtdb.py
+++ b/pyxtdb.py
@@ -1,5 +1,7 @@
 from enum import Enum
 import json
+
+import edn_format
 import requests
 
 
@@ -106,10 +108,20 @@ class Node:
     def parse_kwargs(self, known_args, provided_args):
         params = {}
         for k,v in provided_args.items():
+            # convert from valid python keywords to url parameters,
+            # i.e. from 'with_opsQ' to 'with-ops?'
+            k = k.replace("_","-").replace('Q','?')
             if k not in known_args:
                 raise UnknownParameter(f'Unknown parameter: {k}')
             if v is not None:
-                params[k.replace("_","-").replace('Q','?')] = v
+                # handle formatted values if they are edn or json,
+                # and for now we depend on the convention that
+                # the url parameters are named with the desired format.
+                if k.endswith('-edn'):
+                    v = edn_format.dumps(v)
+                if k.endswith('-json'):
+                    v = json.dumps(v)
+                params[k] = v
         return params
 
     def call_rest_api(self, action, params={}):
@@ -160,18 +172,18 @@ class Node:
             if not in_args:
                 data = "{:query %s}" % query
             else:
-                data = "{:query %s :in-args %s}" % (query, in_args)
+                data = "{:query %s :in-args %s}" % (query, edn_format.dumps(in_args))
         else:
             data = None
 
         # handle url parameters
         known_args = [
-            'query_edn',
-            'in_args_edn',
-            'in_args_json',
-            "valid_time",
-            'tx_time',
-            'tx_id'
+            'query-edn',
+            'in-args-edn',
+            'in-args-json',
+            "valid-time",
+            'tx-time',
+            'tx-id'
         ]
         params = self.parse_kwargs(known_args, kwargs)
 
@@ -190,11 +202,11 @@ class Node:
         action = "entity"
         known_args = [
             'eid',
-            'eid_json',
-            'eid_edn',
-            'valid_time',
-            'tx_time',
-            'tx_id'
+            'eid-json',
+            'eid-edn',
+            'valid-time',
+            'tx-time',
+            'tx-id'
         ]
         params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
@@ -203,17 +215,17 @@ class Node:
         action = "entity?history=true"
         known_args = [
             'eid',
-            'eid_json',
-            'eid_edn',
-            'sort_order',
-            'with_corrections',
-            'with_docs',
-            'start_valid_time',
-            'start_tx_time',
-            'start_tx_id',
-            'end_valid_time',
-            'end_tx_time',
-            'end_tx_id'
+            'eid-json',
+            'eid-edn',
+            'sort-order',
+            'with-corrections',
+            'with-docs',
+            'start-valid-time',
+            'start-tx-time',
+            'start-tx-id',
+            'end-valid-time',
+            'end-tx-time',
+            'end-tx-id'
         ]
         params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
@@ -224,11 +236,11 @@ class Node:
         action = "entity-tx"
         known_args = [
             'eid',
-            'eid_json',
-            'eid_edn',
-            'valid_time',
-            'tx_time',
-            'tx_id'
+            'eid-json',
+            'eid-edn',
+            'valid-time',
+            'tx-time',
+            'tx-id'
         ]
         params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
@@ -245,25 +257,25 @@ class Node:
 
     def awaitTx(self, **kwargs):
         action = "await-tx"
-        known_args = ['tx_id', 'timeout']
+        known_args = ['tx-id', 'timeout']
         params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
     def awaitTxTime(self, **kwargs):
         action = "await-tx-time"
-        known_args = ['tx_time', 'timeout']
+        known_args = ['tx-time', 'timeout']
         params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
     def txLog(self, **kwargs):
         action = "tx-log"
-        known_args = ['after_tx_id', 'with_opsQ']
+        known_args = ['after-tx-id', 'with-ops?']
         params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
     def txCommitted(self, **kwargs):
         action = "tx-committed"
-        known_args = ['tx_id']
+        known_args = ['tx-id']
         params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 

--- a/pyxtdb.py
+++ b/pyxtdb.py
@@ -1,7 +1,15 @@
-import requests
+from enum import Enum
 import json
+import requests
+
 
 class AlreadySent(Exception):
+    pass
+
+class MissingParameter(Exception):
+    pass
+
+class UnknownParameter(Exception):
     pass
 
 class Query:
@@ -55,8 +63,39 @@ class Query:
         else:
             raise StopIteration
 
+class TxOps:
+
+    def __init__(self):
+        self.ops = []
+
+    def put(self, rec, valid_time=None, end_valid_time=None):
+        op = ['put', rec]
+        if valid_time:
+            op.append(valid_time)
+        if valid_time and end_valid_time:
+            op.append(end_valid_time)
+        self.ops.append(op)
+
+    def delete(self, eid, valid_time=None, end_valid_time=None):
+        op = ['delete', eid]
+        if valid_time:
+            op.append(valid_time)
+        if valid_time and end_valid_time:
+            op.append(end_valid_time)
+        self.ops.append(op)
+
+    def evict(self, eid):
+        self.ops.append(['evict', eid])
+
+    def match(self, eid, rec, ops, valid_time=None):
+        self.ops.append(['match', eid, rec, ops])
+
+    def get_all(self):
+        return {'tx-ops': self.ops}
+
 
 class Node:
+
     def __init__(self, uri="http://localhost:3000"):
         self.uri = uri
 
@@ -64,7 +103,16 @@ class Node:
 
         return Query(node=self).find(find_clause)
 
-    def call_rest_api(self, action, params):
+    def parse_kwargs(self, known_args, provided_args):
+        params = {}
+        for k,v in provided_args.items():
+            if k not in known_args:
+                raise UnknownParameter(f'Unknown parameter: {k}')
+            if v is not None:
+                params[k.replace("_","-").replace('Q','?')] = v
+        return params
+
+    def call_rest_api(self, action, params={}):
 
         endpoint = "{}/_xtdb/{}".format(self.uri, action)
 
@@ -74,100 +122,155 @@ class Node:
         }
 
         rsp = requests.get(endpoint, headers=headers, params=params)
+        rsp.raise_for_status()
         return rsp.json()
 
-    def submitTx(self, tx):
+    def submitTx(self, txops):
         action = "submit-tx"
         endpoint = "{}/_xtdb/{}".format(self.uri, action)
         headers = {
             "Content-Type": "application/json; charset=utf-8",
             "Accept": "application/json",
         }
-        rsp = requests.post(endpoint, headers=headers, json=tx)
+        rsp = requests.post(endpoint, headers=headers, json=txops.get_all())
+        rsp.raise_for_status()
         return rsp.json()
 
-    def put(self, rec):
-        transaction = {"tx-ops": [["put", rec]]}
+    def put(self, rec, valid_time=None, end_valid_time=None):
+        op = TxOps()
+        op.put(rec, valid_time, end_valid_time)
+        return self.submitTx(op)
+
+    def delete(self, eid, valid_time=None, end_valid_time=None):
+        op = TxOps()
+        op.delete(eid, valid_time, end_valid_time)
+        return self.submitTx(op)
+
+    def evict(self, eid):
+        op = TxOps()
+        op.evict(eid)
         return self.submitTx(transaction)
 
-    def delete(self, where):
-        transaction = {"tx-ops": [["delete", where]]}
-        return self.submitTx(transaction)
-
-    def evict(self, id):
-        transaction = {"tx-ops": [["evict", id]]}
-        return self.submitTx(transaction)
-
-    def query(self, query):
+    def query(self, query, **kwargs):
         query=query.strip()
         # basic syntax check
         assert query.startswith("{") and query.endswith("}")
+
+        known_args = [
+            "valid_time",
+            'tx_time',
+            'tx_id'
+        ]
+        params = self.parse_kwargs(known_args, kwargs)
 
         action = "query"
         endpoint = "{}/_xtdb/{}".format(self.uri, action)
         headers = {"Accept": "application/json", "Content-Type": "application/edn"}
         query = "{:query %s}" % query
-        rsp = requests.post(endpoint, headers=headers, data=query)
+        rsp = requests.post(endpoint, headers=headers, data=query, params=params)
         return rsp.json()
+
+    def status(self):
+        action = "status"
+        return self.call_rest_api(action)
+
+    def entity(self, **kwargs):
+        action = "entity"
+        known_args = [
+            'eid',
+            'eid_json',
+            'eid_edn',
+            'valid_time',
+            'tx_time',
+            'tx_id'
+        ]
+        params = self.parse_kwargs(known_args, kwargs)
+        return self.call_rest_api(action, params)
+
+    def entityHistory(self, **kwargs):
+        action = "entity?history=true"
+        known_args = [
+            'eid',
+            'eid_json',
+            'eid_edn',
+            'sort_order',
+            'with_corrections',
+            'with_docs',
+            'start_valid_time',
+            'start_tx_time',
+            'start_tx_id',
+            'end_valid_time',
+            'end_tx_time',
+            'end_tx_id'
+        ]
+        params = self.parse_kwargs(known_args, kwargs)
+        return self.call_rest_api(action, params)
 
     # -- TODO: explicit optional params for these, as named Python kwargs.
 
-    def status(self, params):
-        action = "status"
-        return self.call_rest_api(action, params)
-
-    def entity(self, params):
-        action = "entity"
-        return self.call_rest_api(action, params)
-
-    def entityHistoryTrue(self, params):
-        action = "entity?history=true"
-        return self.call_rest_api(action, params)
-
-    def entityTx(self, params):
+    def entityTx(self, **kwargs):
         action = "entity-tx"
+        known_args = [
+            'eid',
+            'eid_json',
+            'eid_edn',
+            'valid_time',
+            'tx_time',
+            'tx_id'
+        ]
+        params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
-    def attributeStats(self, params):
+    def attributeStats(self):
         action = "attribute-stats"
-        return self.call_rest_api(action, params)
+        return self.call_rest_api(action)
 
-    def sync(self, params):
+    def sync(self, **kwargs):
         action = "sync"
+        known_args = ['timeout']
+        params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
-    def awaitTx(self, params):
+    def awaitTx(self, **kwargs):
         action = "await-tx"
+        known_args = ['tx_id', 'timeout']
+        params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
-    def awaitTxTime(self, params):
+    def awaitTxTime(self, **kwargs):
         action = "await-tx-time"
+        known_args = ['tx_time', 'timeout']
+        params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
-    def txLog(self, params):
+    def txLog(self, **kwargs):
         action = "tx-log"
+        known_args = ['after_tx_id', 'with_opsQ']
+        params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
-    def txCommitted(self, params):
+    def txCommitted(self, **kwargs):
         action = "tx-committed"
+        known_args = ['tx_id']
+        params = self.parse_kwargs(known_args, kwargs)
         return self.call_rest_api(action, params)
 
-    def latestCompletedTx(self, params):
+    def latestCompletedTx(self):
         action = "latest-completed-tx"
-        return self.call_rest_api(action, params)
+        return self.call_rest_api(action)
 
-    def latestSubmittedTx(self, params):
+    def latestSubmittedTx(self):
         action = "latest-submitted-tx"
-        return self.call_rest_api(action, params)
+        return self.call_rest_api(action)
 
-    def activeQueries(self, params):
+    def activeQueries(self):
         action = "active-queries"
-        return self.call_rest_api(action, params)
+        return self.call_rest_api(action)
 
-    def recentQueries(self, params):
+    def recentQueries(self):
         action = "recent-queries"
-        return self.call_rest_api(action, params)
+        return self.call_rest_api(action)
 
-    def slowestQueries(self, params):
+    def slowestQueries(self):
         action = "slowest-queries"
-        return self.call_rest_api(action, params)
+        return self.call_rest_api(action)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-watch
+edn_format
 requests

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import os
 import pyxtdb
@@ -13,21 +14,21 @@ def billies(result):
 
 def test_put_and_query(node):
     # Remove record with xt/id "billy", check it's gone.
-    node.evict("billy")
+    result = node.evict("billy").submit()
     # Fetch ALL records
     result = node.query(r"{:find [?e], :where [[?e :xt/id]]}")
     # None should have xt/id "billy"
     assert billies(result) == 0
 
     # Create a record and ensure it's found.
-    node.put({"xt/id": "billy", "name": "Billy", "last-name": "Idol"})
+    result = node.put({"xt/id": "billy", "name": "Billy", "last-name": "Idol"}).submit()
     # Fetch ALL records
     result = node.query(r"{:find [?e], :where [[?e :xt/id]]}")
     # One should have xt/id "billy"
     assert billies(result) == 1
 
     # Ensure it's gone again after deletion.
-    node.evict("billy")
+    result = node.evict("billy").submit()
     # Fetch ALL records
     result = node.query(r"{:find [?e], :where [[?e :xt/id]]}")
     # None should have xt/id "billy"
@@ -35,25 +36,97 @@ def test_put_and_query(node):
 
 def test_query_model(node):
 
-    # Remove record with xt/id "billy", check it's gone.
-    node.evict(1)
-    node.evict(2)
-    node.evict(3)
-    # Fetch ALL records
-    result = node.find("?e").where("?e :xt/id")
+    # Remove records with name "Billy"
+    result = node.evict(1) \
+                 .evict(2) \
+                 .evict(3) \
+                 .submit()
+    # Fetch records with name "Billy"
+    result = node.find("?e").where("?e :name \"Billy\"")
     # None should have xt/id "billy"
     assert len(list(result)) == 0
 
     # Create a record and ensure it's found.
-    node.put({"xt/id": 1, "name": "Billy", "last-name": "Idol"})
-    node.put({"xt/id": 2, "name": "Billy", "last-name": "Joel"})
-    node.put({"xt/id": 3, "name": "Billy", "last-name": "Bob"})
+    result = node.put({"xt/id": 1, "name": "Billy", "last-name": "Idol"}) \
+                 .put({"xt/id": 2, "name": "Billy", "last-name": "Joel"}) \
+                 .put({"xt/id": 3, "name": "Billy", "last-name": "Bob"}) \
+                 .submit()
     
-    # Fetch ALL records
-    result = node.find("?e").where("?e :xt/id")
+    # Fetch records with name "Billy"
+    result = node.find("?e").where("?e :name \"Billy\"")
     assert len(list(result)) == 3
 
     result = node.find("?e").where('?e :last-name "Joel"')
     assert len(list(result)) == 1
     assert result.error == None
-    print(result)
+
+def test_kwargs(node):
+
+    known_args = ['my-foo', 'my-bar?', 'my-json', 'my-edn']
+
+    # confirm keyword underscores become hyphens
+    params = node.parse_kwargs(known_args, {'my_foo': 1})
+    assert 'my-foo' in params
+    assert params['my-foo'] == 1
+
+    # confirm keyword Qs become ?s
+    params = node.parse_kwargs(known_args, {'my_barQ': 1})
+    assert 'my-bar?' in params
+    assert params['my-bar?'] == 1
+
+    # raise exception if keyword not in known_args
+    with pytest.raises(pyxtdb.UnknownParameter) as e:
+        params = node.parse_kwargs(known_args, {'unknown': 'xyzzy'})
+    assert 'Unknown parameter: unknown' in str(e.value)
+
+    # automatic json conversion for keywords ending -json
+    params = node.parse_kwargs(known_args, {'my_json': {'a': 1}})
+    assert params['my-json'] == '{"a": 1}'
+
+    # automatic edn conversion for keywords ending -edn
+    params = node.parse_kwargs(known_args, {'my_edn': {'a': 1}})
+    assert params['my-edn'] == '{"a" 1}'
+
+def test_txops(node):
+    records = [
+        {"xt/id": 10, "band": "King Crimson", "name": "Bill",   "last-name": "Bruford"},
+        {"xt/id": 11, "band": "King Crimson", "name": "Robert", "last-name": "Fripp"},
+        {"xt/id": 12, "band": "King Crimson", "name": "Tony",   "last-name": "Levin"},
+        {"xt/id": 13, "band": "King Crimson", "name": "Adrian", "last-name": "Belew"}
+    ]
+
+    # evict records
+    ids = [rec['xt/id'] for rec in records]
+    result = node.evict(ids).submit()
+
+    # confirm they're gone
+    result = node.query('{:find [?e] :where [[?e :band "King Crimson"]]}')
+    assert len(list(result)) == 0
+
+    # now add the records in a single operation
+    node.put(records).submit()
+
+    # confirm they're there
+    result = node.query('{:find [?e] :where [[?e :band "King Crimson"]]}')
+    assert len(list(result)) == 4
+
+    # delete two records
+    result = node.delete(eid=11) \
+                 .delete(eid=13) \
+                 .submit()
+    result = node.query('{:find [?e] :where [[?e :band "King Crimson"]]}')
+    assert len(list(result)) == 2
+
+    # use match to update the two remaining records
+    for rec in records:
+        result = node.match(rec['xt/id'], rec) \
+                     .put({**rec, 'album': 'Discipline'}) \
+                     .submit()
+
+    # still only two records
+    result = node.query('{:find [?e] :where [[?e :band "King Crimson"]]}')
+    assert len(list(result)) == 2
+
+    # but now they have an album
+    result = node.query('{:find [?e] :where [[?e :band "King Crimson"] [?e :album "Discipline"]]}')
+    assert len(list(result)) == 2


### PR DESCRIPTION
This PR implements:

* kwargs on Node's various operations
    * args are validated via a static method `_parse_kwargs()`.
    * args are auto-converted from python (`tx_time=...`) to URL parameter form (`?tx-time=...`)
    *  the values assigned to kwargs are converted to either json or edn strings where appropriate
*  submit-tx transactions
    * fluent API e.g. `node.put(x).put(y).evict(z).submit()`
    * bulk api e.g. `node.put([x1 x2 x3]).submit()`
* query method (the low-level one, not the high level model)
    * support in-args as a python collection or an edn-formatted string
    * query itself can also be an edn-formatted string or a python dictionary
    * string inputs are validated via the `edn_format` parser
    * support transaction time and valid time filters
* more exception handling
* unit tests for the above